### PR TITLE
Reduce refreshes and allow partial zoom control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.27.0",
+  "version": "0.27.0-debug",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.27.0-debug",
+  "version": "0.27.1-debug",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.27.2-debug",
+  "version": "0.27.3-debug",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.27.1-debug",
+  "version": "0.27.2-debug",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.27.3-debug",
+  "version": "0.28.0",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -395,6 +395,7 @@ export default class ReactCalendarTimeline extends Component {
     // if the items or groups have changed we must re-render
     const forceUpdate = items !== prevState.items || groups !== prevState.groups
 
+    // We are a controlled component
     if (visibleTimeStart && visibleTimeEnd) {
       // Get the new canvas position
       Object.assign(

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -112,8 +112,8 @@ export default class ReactCalendarTimeline extends Component {
     defaultTimeStart: PropTypes.object,
     defaultTimeEnd: PropTypes.object,
 
-    remoteZoomTimeStart: number,
-    remoteZoomTimeEnd: number,
+    zoomTimeStart: number,
+    zoomTimeEnd: number,
 
     visibleTimeStart: PropTypes.number,
     visibleTimeEnd: PropTypes.number,
@@ -209,8 +209,8 @@ export default class ReactCalendarTimeline extends Component {
     defaultTimeStart: null,
     defaultTimeEnd: null,
 
-    remoteZoomTimeStart: null,
-    remoteZoomTimeEnd: null,
+    zoomTimeStart: null,
+    zoomTimeEnd: null,
 
     itemTouchSendsClick: false,
 
@@ -317,8 +317,8 @@ export default class ReactCalendarTimeline extends Component {
 
     this.state = {
       width: 1000,
-      remoteZoomTimeStart: this.props.remoteZoomTimeStart,
-      remoteZoomTimeEnd: this.props.remoteZoomTimeEnd,
+      zoomTimeStart: this.props.zoomTimeStart,
+      zoomTimeEnd: this.props.zoomTimeEnd,
       visibleTimeStart: visibleTimeStart,
       visibleTimeEnd: visibleTimeEnd,
       canvasTimeStart: canvasTimeStart,
@@ -386,7 +386,7 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const { remoteZoomTimeStart, remoteZoomTimeEnd, items, groups } = nextProps
+    const { visibleTimeStart, visibleTimeEnd, zoomTimeStart, zoomTimeEnd, items, groups } = nextProps
 
     // This is a gross hack pushing items and groups in to state only to allow
     // For the forceUpdate check
@@ -395,15 +395,29 @@ export default class ReactCalendarTimeline extends Component {
     // if the items or groups have changed we must re-render
     const forceUpdate = items !== prevState.items || groups !== prevState.groups
 
-    // We want to trigger a refresh with updated time range based on zoom
-    if (remoteZoomTimeStart !== prevState.remoteZoomTimeStart || remoteZoomTimeEnd !== prevState.remoteZoomTimeEnd) {
-      derivedState = { remoteZoomTimeStart, remoteZoomTimeEnd, items, groups }
+    if (visibleTimeStart && visibleTimeEnd) {
       // Get the new canvas position
       Object.assign(
         derivedState,
         calculateScrollCanvas(
-          remoteZoomTimeStart, // visibleTimeStart,
-          remoteZoomTimeEnd, // visibleTimeEnd,
+          visibleTimeStart,
+          visibleTimeEnd,
+          forceUpdate,
+          items,
+          groups,
+          nextProps,
+          prevState
+        )
+      )
+    } else if (zoomTimeStart !== prevState.zoomTimeStart || zoomTimeEnd !== prevState.zoomTimeEnd) {
+      // We want to trigger a refresh with updated time range based on zoom
+      derivedState = { zoomTimeStart, zoomTimeEnd, items, groups }
+      // Get the new canvas position
+      Object.assign(
+        derivedState,
+        calculateScrollCanvas(
+          zoomTimeStart, // visibleTimeStart,
+          zoomTimeEnd, // visibleTimeEnd,
           forceUpdate,
           items,
           groups,

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -461,8 +461,10 @@ export default class ReactCalendarTimeline extends Component {
         (prevState.visibleTimeStart - prevState.canvasTimeStart) /
         oldZoom
     )
+    // Suggested change from https://github.com/namespace-ee/react-calendar-timeline/pull/851
+    this.scrollComponent.scrollLeft = scrollLeft
     if (componentScrollLeft !== scrollLeft) {
-      this.scrollComponent.scrollLeft = scrollLeft
+      // this.scrollComponent.scrollLeft = scrollLeft
       this.scrollHeaderRef.scrollLeft = scrollLeft
     }
   }

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -528,8 +528,8 @@ export default class ReactCalendarTimeline extends Component {
 
     const visibleTimeStart = canvasTimeStart + zoom * scrollX / width
 
-    // Switch to Prop, possible fix for scrolling bounds
-    /* const minTime = 1643047200000;
+    // TODO: Switch to Prop/State for min/max, possible fix for scrolling bounds
+    /* const minTime = this.state.minTime;
     if (visibleTimeStart < minTime) {
       this.scrollComponent.scrollLeft = width;
       this.setState({ visibleTimeStart: this.props.defaultTimeStart.valueOf(), visibleTimeEnd: this.props.defaultTimeStart.valueOf() + zoom });

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -543,13 +543,6 @@ export default class ReactCalendarTimeline extends Component {
 
     const visibleTimeStart = canvasTimeStart + zoom * scrollX / width
 
-    // TODO: Switch to Prop/State for min/max, possible fix for scrolling bounds
-    /* const minTime = this.state.minTime;
-    if (visibleTimeStart < minTime) {
-      this.scrollComponent.scrollLeft = width;
-      this.setState({ visibleTimeStart: this.props.defaultTimeStart.valueOf(), visibleTimeEnd: this.props.defaultTimeStart.valueOf() + zoom });
-    } */
-
     if (
       this.state.visibleTimeStart !== visibleTimeStart ||
       this.state.visibleTimeEnd !== visibleTimeStart + zoom

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -538,7 +538,7 @@ export function stackTimelineItems(
  * @param {*} width
  * @param {*} buffer
  */
-export function getCanvasWidth(width, buffer = 3) {
+export function getCanvasWidth(width, buffer = 1) {
   return width * buffer
 }
 

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -538,7 +538,7 @@ export function stackTimelineItems(
  * @param {*} width
  * @param {*} buffer
  */
-export function getCanvasWidth(width, buffer = 2) {
+export function getCanvasWidth(width, buffer = 3) {
   return width * buffer
 }
 

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -538,7 +538,7 @@ export function stackTimelineItems(
  * @param {*} width
  * @param {*} buffer
  */
-export function getCanvasWidth(width, buffer = 1) {
+export function getCanvasWidth(width, buffer = 2) {
   return width * buffer
 }
 


### PR DESCRIPTION
A couple of changes:

- Add new props that allow us to de-couple changes triggered by remote zoom, and the always updated internal state of visibleTime; This basically allows for partial control as opposed to the full control triggered with the use of visibleTime

I'd like to investigate the comparison in getDerivedStateFromProps:

```
    const forceUpdate = items !== prevState.items || groups !== prevState.groups
```

Since I'm not sure this comparison is always accurate and may be identifying changes when there are none, but that will be a separate ticket.