### PR TITLE
[ROUT-305] Added ability to pass in custom keys to clustering for item start and end times

### DIFF
--- a/src/lib/utility/Cluster.js
+++ b/src/lib/utility/Cluster.js
@@ -1,3 +1,5 @@
+import { _get } from './generic';
+
 export default class Cluster {
     #items = [];
 
@@ -5,8 +7,14 @@ export default class Cluster {
 
     #startTime;
 
-    constructor(group) {
+    #startTimeKey;
+
+    #endTimeKey;
+
+    constructor(group, startTimeKey, endTimeKey) {
       this.#group = group;
+      this.#startTimeKey = startTimeKey;
+      this.#endTimeKey = endTimeKey;
     }
 
     add(item) {
@@ -50,8 +58,8 @@ export default class Cluster {
           id: `Cluster ${this.#group}-${items[0].id}-${items[items.length - 1].id}`,
           group: this.#group,
           title: `Cluster of ${items.length} items`,
-          start: this.#startTime,
-          end: items[items.length - 1].end,
+          [this.#startTimeKey]: this.#startTime,
+          [this.#endTimeKey]: _get(items[items.length - 1], this.#endTimeKey),
           canMove: false,
           canResize: false,
           isCluster: true,

--- a/src/lib/utility/ClusteringService.js
+++ b/src/lib/utility/ClusteringService.js
@@ -85,7 +85,7 @@ export default class ClusteringService {
       if (leftItem && leftItem.canCluster && rightItem && rightItem.canCluster) {
         const leftDistance = this.#getItemStart(currentItem) - this.#getItemEnd(leftItem);
         const rightDistance = this.#getItemStart(rightItem) - this.#getItemEnd(currentItem);
-        //* * LOOK INTO THE MATH */
+
         if (leftDistance <= rightDistance && this.#isWithinClusteringRange(leftDistance)) {
           return leftItem;
         }

--- a/src/lib/utility/calendar.js
+++ b/src/lib/utility/calendar.js
@@ -713,7 +713,6 @@ export function groupItemsByKey(items, key) {
 
 
 export function shouldCluster(clusterSettings, canvasTimeSpan) {
-
   if (!clusterSettings) {
     return false;
   }
@@ -731,7 +730,7 @@ export function getOrderedGroupsWithItems(groups, items, keys, clusterSettings, 
   const groupsWithItems = {};
   const groupKeys = Object.keys(groupOrders);
   const groupedItems = groupItemsByKey(items, keys.itemGroupKey);
-
+  const { itemTimeStartKey, itemTimeEndKey } = keys;
   // Initialize with result object for each group
   for (const element of groupKeys) {
     const groupOrder = groupOrders[element];
@@ -739,7 +738,14 @@ export function getOrderedGroupsWithItems(groups, items, keys, clusterSettings, 
     let _groupedItems = groupedItems[_get(groupOrder.group, keys.groupIdKey)] || [];
 
     if (shouldCluster(clusterSettings, canvasTimeEnd - canvasTimeStart)) {
-      const clusterService = new ClusteringService(_groupedItems, canvasTimeEnd - canvasTimeStart, clusterSettings, _get(groupOrder.group, keys.groupIdKey));
+      const clusterService = new ClusteringService(
+        _groupedItems,
+        canvasTimeEnd - canvasTimeStart,
+        clusterSettings,
+        _get(groupOrder.group, keys.groupIdKey),
+        itemTimeStartKey,
+        itemTimeEndKey,
+      );
       clusterService.cluster();
       _groupedItems = clusterService.items;
     }


### PR DESCRIPTION
[JIRA](https://routific.atlassian.net/browse/ROUT-305?atlOrigin=eyJpIjoiYjlkYzk5OGQyZjdiNDNkOTk3MWJhOWY2Y2I1Yzg2ZWYiLCJwIjoiaiJ9)

###Overview

If someone does not use the default start or end for the item keys in the items they pass into the library, it will not display the clusters as the clusters do not know what keys they are using. This PR allows users to pass in custom start and end keys and have the clusters recognize them. In order to use custom values for the start and end times, they need to set this via the keys option and pass into the timeline. 

const keys = {
  groupIdKey: 'id',
  groupTitleKey: 'title',
  groupRightTitleKey: 'rightTitle',
  itemIdKey: 'id',
  itemTitleKey: 'title',
  itemDivTitleKey: 'title',
  itemGroupKey: 'group',
  itemTimeStartKey: 'start',
  itemTimeEndKey: 'end',
};