### PR TITLE
[ROUT-103] - Add hover affordance on tiny item when clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres (more or less) to [Semantic Versioning](http://semver.org/).
 
-## 0.30.0 (Unreleased)
+## 0.30.6 
+
+### New features
+- Added enableIncreasedHoverOnTinyItem:(boolean) inside of cluster settings. This setting adds a div behind a tinyItem to make it easy to interact with. The size of this div is based on the item + a left and right buffer. This buffer is equal to 49% of the clusteringRange to make sure it does not collide with other items and their clustering ranges. Take a look at the new demo under demo-clustering-increased-hover-affordance. Note: Also added a new prop to your custom render called getTinyItemBufferProps. This returns props for the buffer div you need have which wraps your item. This will also change the position of getItemProps to relative vs absolute automatically and add padding to keep your item in the exact same space it is supposed to be.
+
+## 0.30.5 
 
 ### Fixes and Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres (more or less) to [Semantic Versioning](http://semver.o
 ### New features
 - Added enableIncreasedHoverOnTinyItem:(boolean) inside of cluster settings. This setting adds a div behind a tinyItem to make it easy to interact with. The size of this div is based on the item + a left and right buffer. This buffer is equal to 49% of the clusteringRange to make sure it does not collide with other items and their clustering ranges. Take a look at the new demo under demo-clustering-increased-hover-affordance. Note: Also added a new prop to your custom render called getTinyItemBufferProps. This returns props for the buffer div you need have which wraps your item. This will also change the position of getItemProps to relative vs absolute automatically and add padding to keep your item in the exact same space it is supposed to be.
 
+- Added a new function, getRowItems, inside of rowRender to return all items inside of that row. This will include all items inside of a cluster.
 ## 0.30.5 
 
 ### Fixes and Improvements

--- a/README.md
+++ b/README.md
@@ -605,6 +605,9 @@ horizontalLineClassNamesForGroup={(group) => group.root ? ["row-root"] : []}
 
 Data to be passed to `rowRenderer`'s  `rowData` param. Changing this prop will cause rerender of the `rowRenderer`
 
+## 'getRowItems'
+
+Function to get all items inside of the group for this specific row.
 # Helpers
 
 Helpers are methods provided by `HelperContext`. These helpers power most of the rendered UI in the timeline like: Headers, Markers, Items and row renderers. 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ Can items be dragged around? Can be overridden in the `items` array. Defaults to
 
 Can items be moved between groups? Can be overridden in the `items` array. Defaults to `true`
 
+## canCluster
+When clustering is enabled, you will need to have this property on your items. canCluster: true for items that you wish to be included in the clusterin. canCluster: false for items that you don't want to be included in the clustering.
+
 ## canResize
 
 Can items be resized? Can be overridden in the `items` array. Accepted values: `false`, `"left"`, `"right"`, `"both"`. Defaults to `"right"`. If you pass `true`, it will be treated as `"right"` to not break compatibility with versions 0.9 and below.
@@ -367,18 +370,34 @@ Called when the bounds in the calendar's canvas change. Use it for example to lo
 
 Boolean to hide or show HorizontalLines. `true` by default. Hiding the horizontalLines will have a good impact on performance.
 
+## clusterSettings
+
+An object to enable clustering of items on the timeline. If your items are pre sorted, pass in itemsSorted: true into the timeline to save a double sort.
+
+clusterSettings:{
+  tinyItemSize?: (number: default 0.4),
+  clusteringRange?: (number: default 2.2),
+  sequencialClusterTinyItemsOnly?: (boolean: default True),
+  disableClusteringBelowTime?: (number:):
+  enableIncreasedHoverOnTinyItem?:(boolea)
+}
+
+Look at the demo-clustering || demo-clustering-custom-render || demo-clustering-increased-hover-affordance for examples. Changelog goes into further detail on how it works.
+
 ## itemRenderer
 
 Render prop function used to render a customized item. The function provides multiple parameters that can be used to render each item.
 
 Parameters provided to the function has two types: context params which have the state of the item and timeline, and prop getters functions
 
+## itemRendererCluster
+Render prop function used to render a custom cluster item.  The function provides multiple parameters that can be used to render each item. All items inside of the cluster are available via item.items.
+
 #### Render props params
 
 ##### context
 
 * `item` has the item we passed as a prop to the calendar.
-
 * `timelineContext`
 
 | property           | type     | description                                          |
@@ -396,7 +415,10 @@ Parameters provided to the function has two types: context params which have the
 | `dimensions`      | `object`        | returns the dimensions of the item which includes `collisionLeft`, `collisionWidth`, `height`, `isDragging`, `left`, `order`, `originalLeft`, `stack`, `top`, and `width` |
 | `useResizeHandle` | `boolean`       | returns the prop `useResizeHandle` from calendar root component                                                                                                           |
 | `title`           | `string`        | returns title to render in content element.                                                                                                                               |
-| `canMove`         | `boolean`       | returns if the item is movable.                                                                                                                                           |
+| `canMove`         | `boolean`       | returns if the item is 
+movable.     
+
+| `canCluster`         | `boolean`       | returns if the item is clusterable.                                                                                                                           |
 | `canResizeLeft`   | `boolean`       | returns if the item can resize from the left                                                                                                                              |
 | `canResizeRight`  | `boolean`       | returns if the item can resize from the right.                                                                                                                            |
 | `selected`        | `boolean`       | returns if the item is selected.                                                                                                                                          |

--- a/__fixtures__/clusterItems.js
+++ b/__fixtures__/clusterItems.js
@@ -4,16 +4,18 @@
     Easy to convert MS: https://currentmillis.com/
 */
 export const clusterSettings = {
-  tinyItemSize: 0.4,
+  tinyItemSize: 0.2,
   clusteringRange: 0.5,
   sequencialClusterTinyItemsOnly: true,
   disableClusteringBelowTime: 1000 * 60 * 60 * 12,
+  enableIncreasedHoverOnTinyItem: true,
 };
 
 export const clusterSettingsLarge = {
   tinyItemSize: 10,
   clusteringRange: 20,
   sequencialClusterTinyItemsOnly: true,
+  enableIncreasedHoverOnTinyItem: true,
 };
 
 export const clusterSettingsLgDisableBelow23Hours = {
@@ -21,6 +23,7 @@ export const clusterSettingsLgDisableBelow23Hours = {
   clusteringRange: 20,
   sequencialClusterTinyItemsOnly: true,
   disableClusteringBelowTime: 1000 * 60 * 60 * 24,
+  enableIncreasedHoverOnTinyItem: true,
 };
 export const canvasSize = {
   msBeginingOfDay: 1654498800000, // Mon Jun 06 2022 00:00:00
@@ -35,40 +38,40 @@ export const itemsToCluster = [
 
   {
     id: '1',
-    start: 1654527600000, // Mon Jun 06 2022 08:00:00
-    end: 1654529400000, // Mon Jun 06 2022 08:30:00
+    start_time: 1654527600000, // Mon Jun 06 2022 08:00:00
+    end_time: 1654529400000, // Mon Jun 06 2022 08:30:00
     group: '1',
     canCluster: true,
     title: 'Item 1',
   },
   {
     id: '2',
-    start: 1654530300000, // Mon Jun 06 2022 08:45:00
-    end: 1654531200000, // Mon Jun 06 2022 09:00:00
+    start_time: 1654530300000, // Mon Jun 06 2022 08:45:00
+    end_time: 1654531200000, // Mon Jun 06 2022 09:00:00
     group: '1',
     canCluster: true,
     title: 'Item 2',
   },
   {
     id: '3',
-    start: 1654534800000, // Mon Jun 06 2022 10:00:00
-    end: 1654535400000, // Mon Jun 06 2022 10:10:00
+    start_time: 1654534800000, // Mon Jun 06 2022 10:00:00
+    end_time: 1654535400000, // Mon Jun 06 2022 10:10:00
     group: '1',
     canCluster: true,
     title: 'Item 3',
   },
   {
     id: '4',
-    start: 1654542000000, // Mon Jun 06 2022 12:00:00
-    end: 1654542600000, // Mon Jun 06 2022 12:10:00
+    start_time: 1654542000000, // Mon Jun 06 2022 12:00:00
+    end_time: 1654542600000, // Mon Jun 06 2022 12:10:00
     group: '1',
     canCluster: true,
     title: 'Item 4',
   },
   {
     id: '5',
-    start: 1654545600000, // Mon Jun 06 2022 13:00:00
-    end: 1654547400000, // Mon Jun 06 2022 13:30:00
+    start_time: 1654545600000, // Mon Jun 06 2022 13:00:00
+    end_time: 1654547400000, // Mon Jun 06 2022 13:30:00
     group: '1',
     canCluster: true,
     title: 'Item 5',
@@ -78,24 +81,24 @@ export const itemsToCluster = [
 export const clusterData = [
   {
     id: 'Cluster 1-1-2',
-    start: 1654527600000,
-    end: 1654531200000,
+    start_time: 1654527600000,
+    end_time: 1654531200000,
     group: '1',
     title: 'Cluster 1-1-1',
     isCluster: true,
     canCluster: false,
     items: [{
       id: '1',
-      start: 1654527600000, // Mon Jun 06 2022 08:00:00
-      end: 1654529400000, // Mon Jun 06 2022 08:30:00
+      start_time: 1654527600000, // Mon Jun 06 2022 08:00:00
+      end_time: 1654529400000, // Mon Jun 06 2022 08:30:00
       group: '1',
       canCluster: true,
       title: 'Item 1',
     },
     {
       id: '2',
-      start: 1654530300000, // Mon Jun 06 2022 08:45:00
-      end: 1654531200000, // Mon Jun 06 2022 09:00:00
+      start_time: 1654530300000, // Mon Jun 06 2022 08:45:00
+      end_time: 1654531200000, // Mon Jun 06 2022 09:00:00
       group: '1',
       canCluster: true,
       title: 'Item 2',

--- a/__fixtures__/itemsAndGroups.js
+++ b/__fixtures__/itemsAndGroups.js
@@ -1,3 +1,12 @@
+export const tinyItem = {
+  id: '0',
+  group: '1',
+  start_time: 1540540000000,
+  end_time: 154054000005,
+  canMove: false,
+  canResize: false,
+  title: 'title 0',
+};
 
 export const items = [
   {
@@ -57,7 +66,7 @@ export const items = [
     canResize: false,
     className: '',
     title: 'title 3',
-  }
-]
+  },
+];
 
-export const groups = [{ id: '1' }, { id: '2' }, { id: '3' }]
+export const groups = [{ id: '1' }, { id: '2' }, { id: '3' }];

--- a/__tests__/components/Items/Item.test.js
+++ b/__tests__/components/Items/Item.test.js
@@ -4,10 +4,13 @@ import Item from 'lib/items/Item';
 import { noop } from 'test-utility/index';
 import { defaultItemRenderer } from 'lib/items/defaultItemRenderer';
 import defaultClusterItemRenderer from 'lib/items/defaultClusterItemRenderer';
+import ItemRendererWithHoverAffordance from '../../../demo/app/demo-clustering-increased-hover-affordance/ItemRender';
+
 import render from '../../test-utility/renderWithTimelineStateAndHelpers';
-import { items } from '../../../__fixtures__/itemsAndGroups';
+import { items, tinyItem } from '../../../__fixtures__/itemsAndGroups';
 import { props, state } from '../../../__fixtures__/stateAndProps';
 import { orderedGroups } from '../../../__fixtures__/groupOrderAndItemDimentions';
+import { clusterSettings } from '../../../__fixtures__/clusterItems';
 
 describe('Item', () => {
   it('should render', () => {
@@ -19,7 +22,7 @@ describe('Item', () => {
         order={orderedGroups['1']}
         dimensions={{
           left: 0,
-          width: 100,
+          width: 10,
           collisionLeft: 1572370000000,
           collisionWidth: 11155131,
           top: 3.75,
@@ -64,5 +67,61 @@ describe('Item', () => {
         container: document.body.appendChild(container),
       },
     );
+  });
+
+  it('Should render a buffer around a tinyItem', () => {
+    const container = document.createElement('div');
+    const wrapper = render(<Item
+        item={tinyItem}
+        keys={props.keys}
+        order={orderedGroups['1']}
+        dimensions={{
+          left: 0,
+          width: 100,
+          collisionLeft: 1572370000000,
+          collisionWidth: 11155131,
+          top: 3.75,
+          stack: true,
+          height: 22.5,
+        }}
+        selected={false}
+        canChangeGroup={false}
+        canMove={false}
+        canResizeLeft={false}
+        canResizeRight={false}
+        canSelect={false}
+        useResizeHandle={false}
+        canvasTimeStart={state.canvasTimeStart}
+        canvasTimeEnd={state.canvasTimeEnd}
+        canvasWidth={state.width}
+        dragSnap={props.dragSnap}
+        minResizeWidth={props.minResizeWidth}
+        onResizing={noop}
+        onResized={noop}
+        moveResizeValidator={null}
+        onDrag={noop}
+        onDrop={noop}
+        onItemDoubleClick={noop}
+        onContextMenu={noop}
+        onSelect={noop}
+        itemRenderer={ItemRendererWithHoverAffordance}
+        itemRendererCluster={ItemRendererWithHoverAffordance}
+        clusterSettings={clusterSettings}
+        scrollRef={container}
+        dragging={false}
+        resizing={false}
+        dragOffset={0}
+        resizeEdge={undefined}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onResizeStart={noop}
+        visibleTimeEnd={state.visibleTimeEnd}
+        visibleTimeStart={state.visibleTimeStart}
+        timelineWidth={state.width}
+      />, {
+      container: document.body.appendChild(container),
+    });
+
+    expect(wrapper.getByTestId('buffer-div')).toBeTruthy();
   });
 });

--- a/__tests__/utils/calendar/get-ordered-groups-with-items.js
+++ b/__tests__/utils/calendar/get-ordered-groups-with-items.js
@@ -47,7 +47,7 @@ describe('getGroupWithItemDimensions', () => {
     const expectedItemCount = 5;
     const result = getOrderedGroupsWithItems(clusterGroup, itemsToCluster, props.keys, clusterSettingsLgDisableBelow23Hours, canvasSize.msBeginingOfDay, canvasSize.msEndOfDay);
 
-    expect(result['1'].items.length).toEqual(expectedItemCount);
+    expect(result['1'].items.length).toBe(expectedItemCount);
   });
 
   it('When an item is has canCluster = false, it should not cluster', () => {

--- a/demo/app/demo-clustering-increased-hover-affordance/IncreasedHoverItem.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/IncreasedHoverItem.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const IncreasedHoverItem = (props) => {
+  if (props.isTinyItem) {
+    return (
+      <div {...props.tinyItemBufferProps} onMouseEnter={props.onMouseEnter} onMouseLeave={props.onMouseLeave}>
+      {props.children}
+      </div>
+    );
+  }
+  return <>{props.children}</>;
+};
+
+export default IncreasedHoverItem;

--- a/demo/app/demo-clustering-increased-hover-affordance/IncreasedHoverItem.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/IncreasedHoverItem.js
@@ -3,11 +3,12 @@ import React from 'react';
 const IncreasedHoverItem = (props) => {
   if (props.isTinyItem) {
     return (
-      <div {...props.tinyItemBufferProps} onMouseEnter={props.onMouseEnter} onMouseLeave={props.onMouseLeave}>
+      <div data-testid="buffer-div" {...props.tinyItemBufferProps} onMouseEnter={props.onMouseEnter} onMouseLeave={props.onMouseLeave}>
       {props.children}
       </div>
     );
   }
+
   return <>{props.children}</>;
 };
 

--- a/demo/app/demo-clustering-increased-hover-affordance/Item.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/Item.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import IncreasedHoverItem from './IncreasedHoverItem';
+
+const Item = ({
+  item, itemContext, getItemProps, getTinyItemBufferProps,
+}) => {
+  const [isHovering, setIsHovering] = useState(false);
+
+  const onMouseEnter = () => {
+    setIsHovering(true);
+  };
+
+  const onMouseLeave = () => {
+    setIsHovering(false);
+  };
+
+    // Setting the background color just so you can visually see the hover affordance area.
+  const tinyItemBufferProps = getTinyItemBufferProps({
+    style: {
+      background: isHovering ? 'red' : 'green',
+    },
+  });
+
+  const itemProps = getItemProps({
+    style: {
+      color: 'white',
+      borderColor: item.color,
+      border: 'double 3px',
+      height: '200px !important',
+      borderRadius: 6,
+      borderLeftWidth: itemContext.selected ? 3 : 1,
+      borderRightWidth: itemContext.selected ? 3 : 1,
+      cursor: itemContext.selected ? 'not-allowed' : '',
+      zIndex: isHovering ? 81 : 80,
+    },
+  });
+
+  if (isHovering) {
+    tinyItemBufferProps.style.width = 'auto';
+    itemProps.style.width = 'auto';
+  }
+
+  return (
+    <IncreasedHoverItem isTinyItem={item.isTinyItem} tinyItemBufferProps={tinyItemBufferProps} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+         <div {...itemProps}>
+                <div
+                title={`${item.id}`}
+                style={{
+                  height: itemContext.dimensions.height,
+                  overflow: 'hidden',
+                  paddingLeft: 3,
+                  paddingTop: 1,
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  lineHeight: 1,
+                }}
+                >
+                {itemContext.title}
+                </div>
+            </div>
+    </IncreasedHoverItem>
+  );
+};
+
+export default Item;

--- a/demo/app/demo-clustering-increased-hover-affordance/Item.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/Item.js
@@ -14,7 +14,7 @@ const Item = ({
     setIsHovering(false);
   };
 
-    // Setting the background color just so you can visually see the hover affordance area.
+  // Setting the background color just so you can visually see the hover affordance area.
   const tinyItemBufferProps = getTinyItemBufferProps({
     style: {
       background: isHovering ? 'red' : 'green',
@@ -26,7 +26,6 @@ const Item = ({
       color: 'white',
       borderColor: item.color,
       border: 'double 3px',
-      height: '200px !important',
       borderRadius: 6,
       borderLeftWidth: itemContext.selected ? 3 : 1,
       borderRightWidth: itemContext.selected ? 3 : 1,

--- a/demo/app/demo-clustering-increased-hover-affordance/ItemCluster.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/ItemCluster.js
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import IncreasedHoverItem from './IncreasedHoverItem';
+
+const ItemCluster = ({
+  item, itemContext, getItemProps, getTinyItemBufferProps,
+}) => {
+  const [isHovering, setIsHovering] = useState(false);
+
+  const onMouseEnter = () => {
+    setIsHovering(true);
+  };
+
+  const onMouseLeave = () => {
+    setIsHovering(false);
+  };
+
+    // Setting the background color just so you can visually see the hover affordance area.
+  const tinyItemBufferProps = getTinyItemBufferProps({
+    style: {
+      background: isHovering ? 'red' : 'green',
+    },
+  });
+
+  const itemProps = getItemProps({
+    style: {
+      left: '10px !important',
+      background: itemContext.selected ? 'pink' : 'purple',
+      color: 'white',
+      borderColor: item.color,
+      border: 'double 3px',
+      height: '200px !important',
+      borderRadius: 6,
+      borderLeftWidth: itemContext.selected ? 3 : 1,
+      borderRightWidth: itemContext.selected ? 3 : 1,
+      cursor: itemContext.selected ? 'not-allowed' : '',
+      position: 'relative',
+      zIndex: isHovering ? 81 : 80,
+    },
+  });
+
+  if (isHovering) {
+    tinyItemBufferProps.style.width = 'auto';
+    itemProps.style.width = 'auto';
+  }
+
+  return (
+    <IncreasedHoverItem isTinyItem={item.isTinyItem} tinyItemBufferProps={tinyItemBufferProps} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+         <div {...itemProps}>
+                <div
+                 title={`I have ${item.items.map(clusterItem => `${clusterItem.id}`)}`}
+                style={{
+                  height: itemContext.dimensions.height,
+                  overflow: 'hidden',
+                  paddingLeft: 3,
+                  paddingTop: 1,
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  lineHeight: 1,
+                }}
+                >
+                {itemContext.title}
+                </div>
+            </div>
+    </IncreasedHoverItem>
+  );
+};
+
+export default ItemCluster;

--- a/demo/app/demo-clustering-increased-hover-affordance/ItemRender.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/ItemRender.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import Item from './Item';
+
+
+const ItemRender = ({
+  item,
+  itemContext,
+  getItemProps,
+  getTinyItemBufferProps,
+}) => <Item item={item} itemContext={itemContext} getItemProps={getItemProps} getTinyItemBufferProps={getTinyItemBufferProps}/>;
+export default ItemRender;

--- a/demo/app/demo-clustering-increased-hover-affordance/ItemRenderCluster.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/ItemRenderCluster.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ItemCluster from './ItemCluster';
+
+const ItemRenderCluster = ({
+  item,
+  itemContext,
+  getItemProps,
+  getTinyItemBufferProps,
+}) => <ItemCluster item={item} itemContext={itemContext} getItemProps={getItemProps} getTinyItemBufferProps={getTinyItemBufferProps}/>;
+export default ItemRenderCluster;

--- a/demo/app/demo-clustering-increased-hover-affordance/index.js
+++ b/demo/app/demo-clustering-increased-hover-affordance/index.js
@@ -1,0 +1,187 @@
+/*
+* For this demo, it creates an increased hover area behind a tiny item.
+* We set the background color just so you can see where the area's are.
+* In your implementation, we would not recommend using the color.
+*/
+
+/* eslint-disable no-console */
+import React, { Component } from 'react';
+import moment from 'moment';
+// eslint-disable-next-line
+import faker from 'faker';
+// eslint-disable-next-line import/no-unresolved
+import Timeline from 'react-calendar-timeline';
+import timelineData from '../fake-timeline-data';
+import clusterItemRenderer from './ItemRenderCluster';
+import ItemRender from './ItemRender';
+
+const minTime = moment('2022-MAY-12')
+  .add(-1, 'second')
+  .valueOf();
+const maxTime = moment('2022-MAY-12')
+  .add(36, 'hours')
+  .valueOf();
+
+const keys = {
+  groupIdKey: 'id',
+  groupTitleKey: 'title',
+  groupRightTitleKey: 'rightTitle',
+  itemIdKey: 'id',
+  itemTitleKey: 'title',
+  itemDivTitleKey: 'title',
+  itemGroupKey: 'group',
+  itemTimeStartKey: 'start',
+  itemTimeEndKey: 'end',
+};
+
+const SIXTEEN_HOURS_IN_MS = 1000 * 60 * 60 * 16;
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+
+    const items = timelineData;
+
+    const groups = [{
+      id: '30',
+      title: faker.name.firstName(),
+      rightTitle: faker.name.lastName(),
+      label: `Label ${faker.name.firstName()}`,
+      bgColor: 'red',
+    },
+    {
+      id: '31',
+      title: faker.name.firstName(),
+      rightTitle: faker.name.lastName(),
+      label: `Label ${faker.name.firstName()}`,
+    }, {
+      id: '32',
+      title: faker.name.firstName(),
+      rightTitle: faker.name.lastName(),
+      label: `Label ${faker.name.firstName()}`,
+    }, {
+      id: '33',
+      title: faker.name.firstName(),
+      rightTitle: faker.name.lastName(),
+      label: `Label ${faker.name.firstName()}`,
+    }, {
+      id: '34',
+      title: faker.name.firstName(),
+      rightTitle: faker.name.lastName(),
+      label: `Label ${faker.name.firstName()}`,
+    }];
+    const defaultTimeStart = moment('2022-MAY-12')
+      .startOf('day')
+      .toDate();
+    const defaultTimeEnd = moment('2022-MAY-12')
+      .endOf('day')
+      .toDate();
+
+    groups[0].stackItems = false;
+    groups[0].height = 300;
+    this.state = {
+      groups,
+      items,
+      defaultTimeStart,
+      defaultTimeEnd,
+    };
+  }
+
+  handleCanvasClick = (groupId, time) => {
+    console.log('Canvas clicked', groupId, moment(time).format());
+  }
+
+  handleCanvasContextMenu = (group, time) => {
+    console.log('Canvas context menu', group, moment(time).format());
+  }
+
+  handleItemClick = (itemId, _, time) => {
+    console.log(`Clicked: ${itemId}`, moment(time).format());
+  }
+
+  handleItemSelect = (itemId, _, time) => {
+    console.log(`Selected: ${itemId}`, moment(time).format());
+  }
+
+  handleItemDoubleClick = (itemId, _, time) => {
+    console.log(`Double Click: ${itemId}`, moment(time).format());
+  }
+
+  handleItemContextMenu = (itemId, _, time) => {
+    console.log(`Context Menu: ${itemId}`, moment(time).format());
+  }
+
+  handleItemMove = (itemId, dragTime, newGroupId) => {
+    const { items, groups } = this.state;
+
+    const group = groups.find(i => i.id === newGroupId);
+
+    this.setState({
+      items: items.map(
+        item => (item.id === itemId
+          ? Object.assign({}, item, {
+            start: dragTime,
+            end: dragTime + (item.end - item.start),
+            group: group.id,
+          })
+          : item),
+      ),
+    });
+
+    console.log('Moved', itemId, dragTime, newGroupId);
+  }
+
+  handleTimeChange = (visibleTimeStart, visibleTimeEnd, updateScrollCanvas) => {
+    if (visibleTimeStart < minTime && visibleTimeEnd > maxTime) {
+      updateScrollCanvas(minTime, maxTime);
+    } else if (visibleTimeStart < minTime) {
+      updateScrollCanvas(minTime, minTime + (visibleTimeEnd - visibleTimeStart));
+    } else if (visibleTimeEnd > maxTime) {
+      updateScrollCanvas(maxTime - (visibleTimeEnd - visibleTimeStart), maxTime);
+    } else {
+      updateScrollCanvas(visibleTimeStart, visibleTimeEnd);
+    }
+  }
+
+  render() {
+    const {
+      groups, items, defaultTimeStart, defaultTimeEnd,
+    } = this.state;
+
+    return (
+      <Timeline
+        groups={groups}
+        items={items}
+        keys={keys}
+        sidebarWidth={150}
+        sidebarContent={<div>Above The Left</div>}
+        canMove
+        canResize="right"
+        canSelect
+        itemTouchSendsClick={false}
+        clusterSettings={{
+          tinyItemSize: 0.2,
+          clusteringRange: 0.5,
+          sequencialClusterTinyItemsOnly: true,
+          disableClusteringBelowTime: SIXTEEN_HOURS_IN_MS,
+          enableIncreasedHoverOnTinyItem: true,
+        }}
+        itemSorted
+        itemRenderer={ItemRender}
+        itemRendererCluster={clusterItemRenderer}
+        itemHeightRatio={0.75}
+        defaultTimeStart={defaultTimeStart}
+        defaultTimeEnd={defaultTimeEnd}
+        onCanvasClick={this.handleCanvasClick}
+        onCanvasContextMenu={this.handleCanvasContextMenu}
+        onItemClick={this.handleItemClick}
+        onItemSelect={this.handleItemSelect}
+        onItemContextMenu={this.handleItemContextMenu}
+        onItemMove={this.handleItemMove}
+        onTimeChange={this.handleTimeChange}
+        onItemDoubleClick={this.handleItemDoubleClick}
+        moveResizeValidator={this.moveResizeValidator}
+      />
+    );
+  }
+}

--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -21,6 +21,7 @@ import * as d3 from 'd3';
 
 import generateFakeData from '../generate-fake-data';
 
+console.log('row Items', RowItems);
 const minTime = moment()
   .add(-6, 'months')
   .valueOf();
@@ -317,9 +318,12 @@ export default class App extends Component {
     getLayerRootProps,
     group,
     itemsWithInteractions,
+    getRowItems, // Function you can call to get all items in this specific row.
   }) => {
     const helpers = React.useContext(HelpersContext);
+
     const { itemsToDrag, unavailableSlots, timelineLinks } = rowData;
+
     const groupUnavailableSlots = unavailableSlots[group.id]
       ? unavailableSlots[group.id]
       : [];

--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -21,7 +21,6 @@ import * as d3 from 'd3';
 
 import generateFakeData from '../generate-fake-data';
 
-console.log('row Items', RowItems);
 const minTime = moment()
   .add(-6, 'months')
   .valueOf();

--- a/demo/app/index.js
+++ b/demo/app/index.js
@@ -23,6 +23,7 @@ const demos = {
   controledSelect: require('./demo-controlled-select').default,
   clusteringItems: require('./demo-clustering').default,
   clusteringItemsCustomRender: require('./demo-clustering-custom-render').default,
+  clusteringHoverAffordance: require('./demo-clustering-increased-hover-affordance').default,
 };
 
 // A simple component that shows the pathname of the current location

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.30.5",
+  "version": "0.30.6",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -1056,6 +1056,7 @@ export default class ReactCalendarTimeline extends Component {
                         canMove={this.props.canMove}
                         canResize={this.props.canResize}
                         canSelect={this.props.canSelect}
+                        clusterSettings={this.props.clusterSettings}
                         useResizeHandle={this.props.useResizeHandle}
                         dragSnap={this.props.dragSnap}
                         minResizeWidth={this.props.minResizeWidth}

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -528,9 +528,9 @@ export default class Item extends Component {
 
     if (item.isTinyItem) {
       const { dimensions } = this.props;
-      const leftBuffer = item.start - ((this.props.clusterSettings?.clusteringRange * percentOfClusteringRange) / 100) * (this.props.canvasTimeEnd - this.props.canvasTimeStart);
-      const rightBuffer = item.end + ((this.props.clusterSettings?.clusteringRange * percentOfClusteringRange) / 100) * (this.props.canvasTimeEnd - this.props.canvasTimeStart);
-
+      const buffer = ((this.props.clusterSettings?.clusteringRange * percentOfClusteringRange) / 100) * (this.props.canvasTimeEnd - this.props.canvasTimeStart);
+      const leftBuffer = item.start - buffer;
+      const rightBuffer = item.end + buffer;
       const position = calculateDimensions(
         {
           itemTimeStart: leftBuffer,

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -519,18 +519,25 @@ export default class Item extends Component {
 
   setTinyItemStatus = () => {
     const { itemTimeStartKey, itemTimeEndKey } = this.props.keys;
-    this.props.item.isTinyItem = isTinyItem(this.props.item, itemTimeStartKey, itemTimeEndKey, this.props.canvasTimeEnd - this.props.canvasTimeStart, this.props.clusterSettings.tinyItemSize);
+    this.props.item.isTinyItem = isTinyItem(
+      this.props.item,
+      itemTimeStartKey, itemTimeEndKey,
+      this.props.canvasTimeEnd - this.props.canvasTimeStart,
+      this.props.clusterSettings.tinyItemSize,
+    );
   }
 
   getTinyItemBufferProps = (props = {}) => {
     const { item } = this.props;
+    const { itemTimeStartKey, itemTimeEndKey } = this.props.keys;
+
     const percentOfClusteringRange = 0.49;
 
     if (item.isTinyItem) {
       const { dimensions } = this.props;
       const buffer = ((this.props.clusterSettings?.clusteringRange * percentOfClusteringRange) / 100) * (this.props.canvasTimeEnd - this.props.canvasTimeStart);
-      const leftBuffer = item.start - buffer;
-      const rightBuffer = item.end + buffer;
+      const leftBuffer = _get(item, itemTimeStartKey) - buffer;
+      const rightBuffer = _get(item, itemTimeEndKey) + buffer;
       const position = calculateDimensions(
         {
           itemTimeStart: leftBuffer,
@@ -545,7 +552,6 @@ export default class Item extends Component {
         id: `${this.itemId}-buffer`,
         key: `${this.itemId}-buffer`,
         style: {
-          background: 'purple',
           position: 'absolute',
           boxSizing: 'border-box',
           left: `${position.left}px`,
@@ -556,7 +562,6 @@ export default class Item extends Component {
           paddingLeft: `${((position.width - dimensions.width) / 2)}px`,
           cursor: 'pointer',
           ...props.style,
-
         },
       };
     }
@@ -612,7 +617,7 @@ export default class Item extends Component {
     } = this.props;
     const renderer = this.props.item.isCluster ? itemRendererCluster : itemRenderer;
 
-    if (clusterSettings && clusterSettings.enableIncreasedHoverOnTinyItem) {
+    if (clusterSettings && clusterSettings.enableIncreasedHoverOnTinyItem && item.canCluster) {
       this.setTinyItemStatus();
     }
 

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -525,6 +525,7 @@ export default class Item extends Component {
   getTinyItemBufferProps = (props = {}) => {
     const { item } = this.props;
     const percentOfClusteringRange = 0.49;
+
     if (item.isTinyItem) {
       const { dimensions } = this.props;
       const leftBuffer = item.start - ((this.props.clusterSettings?.clusteringRange * percentOfClusteringRange) / 100) * (this.props.canvasTimeEnd - this.props.canvasTimeStart);
@@ -539,8 +540,8 @@ export default class Item extends Component {
           canvasWidth: this.props.canvasWidth,
         },
       );
-      console.log('The props are', props.style);
-      const test = {
+
+      return {
         id: `${this.itemId}-buffer`,
         key: `${this.itemId}-buffer`,
         style: {
@@ -558,8 +559,8 @@ export default class Item extends Component {
 
         },
       };
-      return test;
     }
+
     return {
       id: `${this.itemId}-buffer`,
       key: `${this.itemId}-buffer`,

--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -110,6 +110,7 @@ export class Items extends Component {
       items,
     } = this.props;
     const { itemIdKey } = keys;
+
     return (
       <div className="rct-items">
         {items.map((item, i) => {
@@ -143,6 +144,7 @@ export class Items extends Component {
             canvasTimeStart={this.props.canvasTimeStart}
             canvasTimeEnd={this.props.canvasTimeEnd}
             canvasWidth={this.props.canvasWidth}
+            clusterSettings={this.props.clusterSettings}
             dragSnap={this.props.dragSnap}
             minResizeWidth={this.props.minResizeWidth}
             onResizing={this.props.itemResizing}

--- a/src/lib/items/ItemsContext.js
+++ b/src/lib/items/ItemsContext.js
@@ -59,6 +59,7 @@ export class ItemsContextProvider extends PureComponent {
     onItemContextMenu: PropTypes.func,
     itemRenderer: PropTypes.func,
     itemRendererCluster: PropTypes.func,
+    clusteringRange: PropTypes.object,
     selected: PropTypes.array,
     groupDimensions: PropTypes.object,
     useResizeHandle: PropTypes.bool,

--- a/src/lib/items/defaultItemRenderer.js
+++ b/src/lib/items/defaultItemRenderer.js
@@ -5,9 +5,11 @@ export const defaultItemRenderer = ({
   item,
   itemContext,
   getItemProps,
+  getTinyItemBufferProps,
   getResizeProps,
 }) => {
   const { left: leftResizeProps, right: rightResizeProps } = getResizeProps();
+
   return (
     <div {...getItemProps(item.itemProps)}>
       {itemContext.useResizeHandle ? <div {...leftResizeProps} /> : ''}
@@ -30,5 +32,6 @@ defaultItemRenderer.propTypes = {
   item: PropTypes.any,
   itemContext: PropTypes.any,
   getItemProps: PropTypes.any,
+  getTinyItemBufferProps: PropTypes.any,
   getResizeProps: PropTypes.any,
 };

--- a/src/lib/rows/Rows.js
+++ b/src/lib/rows/Rows.js
@@ -54,6 +54,7 @@ class Rows extends React.PureComponent {
       groups,
       itemRenderer,
       itemRendererCluster,
+      clusterSettings,
       canChangeGroup,
       canMove,
       canResize,
@@ -123,6 +124,7 @@ class Rows extends React.PureComponent {
                 onItemContextMenu={onItemContextMenu}
                 itemRenderer={itemRenderer}
                 itemRendererCluster={itemRendererCluster}
+                clusterSettings={clusterSettings}
                 selected={selected}
                 useResizeHandle={useResizeHandle}
                 scrollRef={scrollRef}
@@ -174,6 +176,7 @@ class Group extends React.PureComponent {
       onItemContextMenu,
       itemRenderer,
       itemRendererCluster,
+      clusterSettings,
       selected,
       useResizeHandle,
       scrollRef,
@@ -222,6 +225,7 @@ class Group extends React.PureComponent {
           onItemContextMenu={onItemContextMenu}
           itemRenderer={itemRenderer}
           itemRendererCluster={itemRendererCluster}
+          clusterSettings={clusterSettings}
           selected={selected}
           useResizeHandle={useResizeHandle}
           scrollRef={scrollRef}

--- a/src/lib/rows/Rows.js
+++ b/src/lib/rows/Rows.js
@@ -246,6 +246,7 @@ class Group extends React.PureComponent {
                 rowData={rowData}
                 group={group.group}
                 itemsWithInteractions={itemsWithInteractions}
+                getRowItems={() => group.items}
               />
             )}
           </LayerConsumer>

--- a/src/lib/utility/ClusteringService.js
+++ b/src/lib/utility/ClusteringService.js
@@ -52,7 +52,6 @@ export default class ClusteringService {
       this.#sequencialClusterTinyItemsOnly = sequencialClusterTinyItemsOnly;
       this.#startKey = startKey;
       this.#endKey = endKey;
-      console.log('I have', items, timeRange, tinyItemSize, clusteringRange, sequencialClusterTinyItemsOnly, groupNumber, startKey, endKey);
     }
 
     #getItemStart(item) {

--- a/src/lib/utility/ClusteringService.js
+++ b/src/lib/utility/ClusteringService.js
@@ -3,7 +3,9 @@
 
 import PropTypes from 'prop-types';
 import Cluster from './Cluster';
-import { _get, _length, _pop } from './generic';
+import {
+  isTinyItem, _get, _length, _pop,
+} from './generic';
 
 export default class ClusteringService {
     #items;
@@ -61,12 +63,7 @@ export default class ClusteringService {
     }
 
     #isTinyItem(item) {
-      let itemLength = 0;
-
-      if (this.#getItemStart(item) !== undefined && this.#getItemEnd(item) !== undefined) {
-        itemLength = (this.#getItemEnd(item) - this.#getItemStart(item)) || 0;
-      }
-      return (itemLength / this.#timeRange) * 100 <= this.#tinyItemSize;
+      return isTinyItem(item, this.#startKey, this.#endKey, this.#timeRange, this.#tinyItemSize);
     }
 
     #getItemAtIndex(index) {

--- a/src/lib/utility/ClusteringService.js
+++ b/src/lib/utility/ClusteringService.js
@@ -52,6 +52,7 @@ export default class ClusteringService {
       this.#sequencialClusterTinyItemsOnly = sequencialClusterTinyItemsOnly;
       this.#startKey = startKey;
       this.#endKey = endKey;
+      console.log('I have', items, timeRange, tinyItemSize, clusteringRange, sequencialClusterTinyItemsOnly, groupNumber, startKey, endKey);
     }
 
     #getItemStart(item) {

--- a/src/lib/utility/generic.js
+++ b/src/lib/utility/generic.js
@@ -42,4 +42,11 @@ export function keyBy(value, key) {
   return obj;
 }
 
+export function isTinyItem(item, startKey, endKey, timeRange, tinyItemSize) {
+  let itemLength = 0;
+  if (_get(item, startKey) !== undefined && _get(item, endKey) !== undefined) {
+    itemLength = (_get(item, endKey) - _get(item, startKey)) || 0;
+  }
+  return (itemLength / timeRange) * 100 <= tinyItemSize;
+}
 export function noop() {}


### PR DESCRIPTION
[Jira](https://routific.atlassian.net/browse/ROUT-103?atlOrigin=eyJpIjoiYjQ0OWVjNDQ0YjI1NDdhYjhiOWY2YTMyMmUwNjQ5YmMiLCJwIjoiaiJ9)

**Overview of PR**
-> This PR includes adding extra hover affordance around item when clustering. The issue this solves is that when zooming, items or clusters can become small and hard to interact with, we add an extra area for users to interact with tiny items. When an item is classified as a tiny item, by the clustering settings, we add a div behind the item so you can trigger hover or interaction events on the item. The increased hover affordance is equal to 49% of the clustering range so it will scale with zooming.
-> Changelog/Readme updated
-> Test added to check that a buffer item is added when dealing with a tinyItem that has clusteringSettings.enableIncreasedHoverOnTinyItem = true
-> Demo added to show increased hover under demo-clustering-increased-hovering called clusteringHoverAffordance.
