### PR TITLE
[ROUT-6234] Update prop types to accept observer component and fix console error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routific/react-calendar-timeline",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "react calendar timeline",
   "main": "lib/index.js",
   "scripts": {
@@ -114,6 +114,7 @@
     "@babel/core": "^7.5.0",
     "@babel/plugin-proposal-class-properties": "^7.5.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.5.2",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/preset-env": "^7.5.2",
     "@babel/preset-react": "^7.0.0",
     "@testing-library/jest-dom": "^4.2.0",

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -184,7 +184,10 @@ export default class ReactCalendarTimeline extends Component {
 
     children: PropTypes.node,
 
-    rowRenderer: PropTypes.func,
+    rowRenderer: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object,
+    ]),
     rowData: PropTypes.object,
     hideHorizontalLines: PropTypes.bool,
   }


### PR DESCRIPTION
The library expects a function, and we're supplying a component wrapped with observer from MobX. This makes it an object and therefore throws the console error:

```
fs.js:4 Warning: Failed prop type: Invalid prop `rowRenderer` of type `object` supplied to `ReactCalendarTimeline`, expected `function`.
    in ReactCalendarTimeline (at RoutesGanttChart/index.tsx:219)
```

This PR is to address this error. 
